### PR TITLE
EXPOSE Command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,3 +5,4 @@ LABEL EMPLOYEE="Bhargavi"\
       JOB="Devops"\
       LOCATION="Reading"
 
+EXPOSE 8080/tcp


### PR DESCRIPTION
EXPOSE is the instruction it informs docker that the container listens on the specific network ports at runtime